### PR TITLE
Configure build-scan plugin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
           keys:
             - v1-gradle-{{ checksum "gradle/dependency-locks/compileClasspath.lockfile" }}-{{ checksum "gradle/dependency-locks/testCompileClasspath.lockfile" }}
             - v1-gradle-
-      - run: ./gradlew check --info
+      - run: ./gradlew check --info --scan
       - run:
           name: Save test results
           command: |
@@ -36,5 +36,5 @@ jobs:
               git config --global user.name "kamatama41"
               git checkout master
               git reset --hard origin/master
-              ./gradlew release -Prelease.useAutomaticVersion=true
+              ./gradlew release -Prelease.useAutomaticVersion=true --scan
             fi

--- a/build.gradle
+++ b/build.gradle
@@ -9,11 +9,18 @@ buildscript {
 }
 
 plugins {
+    id "com.gradle.build-scan" version "2.2.1"
     id "com.gradle.plugin-publish" version "0.10.1"
     id "java-gradle-plugin"
     id "org.jetbrains.kotlin.jvm" version "1.3.21"
     id "idea"
 }
+
+buildScan {
+    termsOfServiceUrl   = "https://gradle.com/terms-of-service"
+    termsOfServiceAgree = "yes"
+}
+
 apply plugin: "com.github.kamatama41.git-release"
 
 repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,4 @@
 version=0.3.1-SNAPSHOT
+org.gradle.daemon   = true
+org.gradle.caching  = true
+org.gradle.parallel = true


### PR DESCRIPTION
This small PR configures the `build-scan` Gradle plugin (https://guides.gradle.org/creating-build-scans/) which yields further insight into the build, allowing the team to make informed decisions on where and when the build may be tweaked to get faster, more performant builds.